### PR TITLE
Fix libboost dyld (dynamic linker) paths on OSX

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,6 +67,16 @@ if [ "$?" -ne 0 ]; then
    exit 1
 fi
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # Fix libboost linker paths on OSX
+    cd stage/lib
+
+    for f in *.dylib
+    do
+      install_name_tool -id "@executable_path/../libs/boost_1_53_0/stage/lib/$f" $f
+    done
+fi
+
 cd "$STOCHKIT_HOME"
 
 make -j 4
@@ -86,7 +96,7 @@ if [ "$?" -eq 2 ]; then
 fi
 
 #echo "**********************************************"
-#echo "Please remember to add $STOCHKIT_HOME/libs/boost_1_53_0/stage/lib/ to the LD_LIBRARY_PATH environment variable on Linux machines, or the DYLD_LIBRARY_PATH environment variable on Mac machines."
+#echo "Please remember to add $STOCHKIT_HOME/libs/boost_1_53_0/stage/lib/ to the LD_LIBRARY_PATH environment variable on Linux machines."
 echo "You may add the home directory of StochKit to the PATH environment variable to run ssa or tau_leaping from any directories."
 #echo "**********************************************"
 


### PR DESCRIPTION
System Integrity Protection (SIP) on OSX "El Capitan" means that the
DYLD_LIBRARY_PATH environment variable can no longer be used. This fix to
the StochKit installer script circumvents the problem by assigning relative
paths to each of the libboost*.dylib files after boost is built, which
are passed on to each executable linking against those dylibs. They are
then automatically found at runtime without having to set any environment
variables.
