### PR TITLE
Use absolute paths to shared libraries on OSX

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 
     for f in *.dylib
     do
-      install_name_tool -id "@executable_path/../libs/boost_1_53_0/stage/lib/$f" $f
+      install_name_tool -id "$STOCHKIT_HOME/libs/boost_1_53_0/stage/lib/$f" $f
     done
 fi
 


### PR DESCRIPTION
The relative path approach for dyld (using @executable_path) didn't seem to
work consistently for everyone. This patch makes the installer set a fixed
absolute path to each of the shared libraries, which should mean they're
reliably found at runtime.
